### PR TITLE
Handle Northern Cyprus flag exception by returning 'unknown' as no flag is available on flagcdn

### DIFF
--- a/src/app/utils/countryUtils.ts
+++ b/src/app/utils/countryUtils.ts
@@ -21,6 +21,7 @@ export const getCountryCodeFromName = (countryName: string): string => {
   }
 
   // Attempt to retrieve the ISO Alpha-2 code for the given country name
+  // Northern Cyprus does not have a flag in flagcdn, so no flag will be displayed
   const isoCode = countryToAlpha2(countryName);
 
   // If no matching country is found, return 'unknown'


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Close #1188 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines(linter) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed the code I wrote has been imported with a relative path
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]

| Mobile |  PC  | 
| ---- | ---- | 
|  ![]()  | ![]() | 