### PR TITLE
Add Tweet and YouTube Video Engagement Data Types to AffiliatePerformanceData

### DIFF
--- a/src/app/types/affiliateInfo.ts
+++ b/src/app/types/affiliateInfo.ts
@@ -56,7 +56,7 @@ export type TweetMetrics = {
 
 // Represents a tweet document within the tweets subcollection
 export type TweetData = {
-  tweetId?: string;             // Unique identifier for the tweet
+  tweetId?: string;            // Unique identifier for the tweet
   tweetText: string;           // The content of the tweet
   tweetUrl: string;            // URL link to the tweet
   metrics: TweetMetrics;       // Engagement metrics (public or private)
@@ -128,4 +128,39 @@ export type YouTubeAccountInfo = {
     hiddenSubscriberCount: boolean; // Indicates if the subscriber count is hidden
     videoCount: string;             // Total number of videos uploaded by the user
   };
+};
+
+// Represents engagement statistics for a specific YouTube video
+export type YouTubeVideoStatistics = {
+  commentCount: number;         // Number of comments on the video
+  dislikeCount: number;         // Number of dislikes on the video
+  favoriteCount: number;        // Number of times the video has been favorited
+  likeCount: number;            // Number of likes on the video
+  viewCount: number;            // Number of views on the video
+};
+
+// Represents details of a thumbnail image for a YouTube video at a specific resolution
+export type YouTubeThumbnail = {
+  url: string;                  // URL of the thumbnail image
+  width: number;                // Width of the thumbnail image in pixels
+  height: number;               // Height of the thumbnail image in pixels
+};
+
+// Represents the set of available thumbnail images for a YouTube video at different resolutions
+export type YouTubeThumbnails = {
+  default: YouTubeThumbnail;    // Default resolution thumbnail
+  medium: YouTubeThumbnail;     // Medium resolution thumbnail
+  high: YouTubeThumbnail;       // High resolution thumbnail
+};
+
+// Represents a YouTube video document within the youtubeVideos subcollection in Firestore
+export type YouTubeVideoData = {
+  videoId?: string;                  // Unique identifier for the YouTube video
+  title: string;                     // Title of the video
+  description: string;               // Description of the video
+  statistics: YouTubeVideoStatistics; // Engagement statistics for the video
+  thumbnails: YouTubeThumbnails;     // Thumbnails of the video in various resolutions
+  publishedAt: Date;                 // Date and time the video was published
+  fetchCount: number;                // Number of times the engagement data has been fetched
+  lastFetchedAt: Date;               // The last time the engagement data was updated
 };

--- a/src/app/types/referralTypes.ts
+++ b/src/app/types/referralTypes.ts
@@ -1,3 +1,5 @@
+import { TweetData, YouTubeVideoData } from "./affiliateInfo";
+
 // Type for storing basic referral-related information
 export type ReferralData = {
   id?: string;                    // Optional unique identifier for the referral
@@ -37,9 +39,11 @@ export type ClickData = {
 
 // Type representing comprehensive performance data for an affiliate, including username, click data, conversion data, and social media engagement metrics.
 export type AffiliatePerformanceData = ReferralData & {
-  username: string;               // Username of the affiliate
-  clicks: ClickData[];            // Array of click data associated with the referral
-  conversionLogs: ConversionLog[];   // Array of conversion log entries tracking each successful conversion
+  username: string;                     // Username of the affiliate
+  clicks: ClickData[];                  // Array of click data associated with the referral
+  conversionLogs: ConversionLog[];      // Array of conversion log entries tracking each successful conversion
+  tweets?: TweetData[];                 // Optional array of tweet engagement data associated with the affiliate
+  youtubeVideos?: YouTubeVideoData[];   // Optional array of YouTube video engagement data associated with the affiliate
 };
 
 // Extended type with aggregated fields for earnings and conversions


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Close #1483 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines(linter) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed the code I wrote has been imported with a relative path
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]

| Mobile |  PC  | 
| ---- | ---- | 
|  ![]()  | ![]() | 